### PR TITLE
fix: presets align left

### DIFF
--- a/src/style/Panel.less
+++ b/src/style/Panel.less
@@ -26,6 +26,7 @@
     padding: 6px 8px;
     margin-top: 0;
     border-top: 1px solid #ccc;
+    text-align: left;
 
     &-block {
       width: 100%;


### PR DESCRIPTION
preset 位置会受上层元素 `text-align` 影响，这里固定成 `left`